### PR TITLE
updated page show and listings w schema changes

### DIFF
--- a/wiki_app/app/controllers/wiki_posts_controller.rb
+++ b/wiki_app/app/controllers/wiki_posts_controller.rb
@@ -1,5 +1,5 @@
 class WikiPostsController < ApplicationController
-  before_action :set_wiki_post, only: %i[ edit update destroy ]
+  before_action :set_wiki_post, only: %i[ show edit update destroy ]
 
   # GET /wiki_posts or /wiki_posts.json
   def index
@@ -8,7 +8,7 @@ class WikiPostsController < ApplicationController
 
   # GET /wiki_posts/1 or /wiki_posts/1.json
   def show
-    render "example"
+    @wiki_post = WikiPost.find(params[:id])
   end
 
   # GET /wiki_posts/new

--- a/wiki_app/app/views/wiki_posts/index.html.erb
+++ b/wiki_app/app/views/wiki_posts/index.html.erb
@@ -2,13 +2,14 @@
 
 <h1>Wiki posts</h1>
 
-<div id="wiki_posts">
-  <% @wiki_posts.each do |wiki_post| %>
-    <%= render wiki_post %>
-    <p>
-      <%= link_to "Show this wiki post", wiki_post %>
-    </p>
-  <% end %>
+<div id="wiki_posts" class="mt-4">
+  <ul class="list-none">
+    <% @wiki_posts.each do |wiki_post| %>
+      <li class="mb-2">
+        <%= link_to wiki_post.title, wiki_post, class: "text-blue-600 hover:text-blue-800" %>
+      </li>
+    <% end %>
+  </ul>
 </div>
 
 <%= link_to "New wiki post", new_wiki_post_path %>

--- a/wiki_app/app/views/wiki_posts/show.html.erb
+++ b/wiki_app/app/views/wiki_posts/show.html.erb
@@ -1,5 +1,7 @@
 <p style="color: green"><%= notice %></p>
 
+<h1><%= @wiki_post.title %></h1>
+
 <%= render @wiki_post %>
 
 <div>

--- a/wiki_app/db/migrate/20250422185520_add_title_to_wiki_post.rb
+++ b/wiki_app/db/migrate/20250422185520_add_title_to_wiki_post.rb
@@ -1,0 +1,5 @@
+class AddTitleToWikiPost < ActiveRecord::Migration[7.1]
+  def change
+    add_column :wiki_posts, :title, :string
+  end
+end

--- a/wiki_app/db/schema.rb
+++ b/wiki_app/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_22_183742) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_22_185520) do
   create_table "wiki_posts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
   end
 
 end


### PR DESCRIPTION
This pull request introduces enhancements to the `WikiPosts` feature, including a new `title` attribute for `WikiPost` records, updates to the `show` and `index` views, and adjustments to the controller to support these changes. These updates improve both the functionality and user experience of the application.

### Database and Model Updates:
* Added a new `title` column to the `wiki_posts` table through a migration (`AddTitleToWikiPost`) and updated the schema to reflect this change. [[1]](diffhunk://#diff-3631b87f1ae13fdfa3af63c5bf3c2047c865d881a62e56d92d164d8c545bc389R1-R5) [[2]](diffhunk://#diff-7f6b118ffa970924197bba972dddf23d876aca014e54939689c9915e4208c7a9L13-R17)

### Controller Updates:
* Modified the `before_action` in `WikiPostsController` to include the `show` action, ensuring the `@wiki_post` instance variable is set for rendering the `show` view.
* Updated the `show` action to fetch the specific `WikiPost` record using `params[:id]`, replacing the placeholder render logic.

### View Enhancements:
* Improved the `index.html.erb` view by adding a styled, unordered list for displaying links to each `WikiPost`'s `show` page, using Tailwind CSS classes for better design.
* Enhanced the `show.html.erb` view to display the `title` of the `WikiPost` prominently at the top of the page.