### PR TITLE
example routes

### DIFF
--- a/wiki_app/app/controllers/wiki_posts_controller.rb
+++ b/wiki_app/app/controllers/wiki_posts_controller.rb
@@ -11,6 +11,10 @@ class WikiPostsController < ApplicationController
     @wiki_post = WikiPost.find(params[:id])
   end
 
+  def example
+    render :example
+  end
+
   # GET /wiki_posts/new
   def new
     @wiki_post = WikiPost.new

--- a/wiki_app/config/routes.rb
+++ b/wiki_app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'wiki_posts/example', to: 'wiki_posts#example'
   resources :wiki_posts
   get 'welcome/index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
This pull request adds a new example action and corresponding route to the `wiki_posts` controller and routing configuration. These changes enable rendering an example view for wiki posts.

Controller changes:

* [`wiki_app/app/controllers/wiki_posts_controller.rb`](diffhunk://#diff-21b2b88b030f3464e7958f8405d239b64fdabe2e4c2fb792a82c1ba5fa658842R14-R17): Added a new `example` action that renders the `example` view.

Routing changes:

* [`wiki_app/config/routes.rb`](diffhunk://#diff-9b89f4c4ad4ca08e7ea8a2f7833a84f4324b4b897bb05f38d134052ad3b76056R2): Added a new route to map `GET /wiki_posts/example` to the `example` action in the `wiki_posts` controller.